### PR TITLE
1. install script cleanup dummy bak file; 2. Developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ For now, this credential helper works in tandem with the Azure CLI, which is req
 ## Installation
 For Windows, run the [powershell installation script](https://aka.ms/acr/installaad/win) in administrator mode:
 
-`iex ([System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Uri https://aka.ms/acr/installaad/win).Content))`
+```iex ([System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Uri https://aka.ms/acr/installaad/win).Content))```
 
 For Linux and macOS, run the [bash installation script](https://aka.ms/acr/installaad/bash) as root:
 
-`curl -L https://aka.ms/acr/installaad/bash | sudo /bin/bash`
+```curl -L https://aka.ms/acr/installaad/bash | sudo /bin/bash```
 
 ## Usage
 After installing the ACR Docker Credential Helper, login to an Azure Container Registry using the Azure CLI:
-    `az acr login -n <registry name>`
+
+```az acr login -n <registry name>```
 
 After that, you will be able to use docker normally. This credential helper will help maintaining your credentials.
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ After installing the ACR Docker Credential Helper, login to an Azure Container R
 
 After that, you will be able to use docker normally. This credential helper will help maintaining your credentials.
 
-## Building
-Invoking [build.sh](build.sh) will build and launch a docker container and perform a cross-platform build
+## Developer Guide:
+
+To manually build and launch this credential helper:
+- Invoke [build.sh](build.sh) to build and launch a docker container and perform a cross-platform build.
+- Find the appropriate `docker-credential-acr-<osname>-<arch>` archive in the `artifacts` directory. Extract the appropriate archive for your os and place the `docker-credential-acr-<osname>` executable file to any directory under your `PATH`.
+- Add the following entry to your docker `config.json`
+    ```
+    {
+        "credsStore": "acr-<osname>"
+    }
+    ```
 
 ## Troubleshooting
 ### Getting 401 (authentication required)

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -58,11 +58,16 @@ if (!(Test-Path $configDir)) {
 $configFile = Join-Path $configDir "config.json"
 
 if (!(Test-Path $configFile)) {
+    $dummyConfigCreated = $true
     Write-Output '{"auths":{}}' | Out-File $configFile -Encoding ASCII
 }
 
 $configEditPath = [System.IO.Path]::Combine(".", $tempdir, "config-edit.exe")
 &$configEditPath "--helper" "acr-windows" "--config-file" "${configFile}"
+
+if ($dummyConfigCreated) {
+    Remove-Item -Force "${configFile}.bak"
+}
 
 if (!$skipCleanup) {
     Remove-Item -Force -Recurse $tempdir

--- a/install/install.sh
+++ b/install/install.sh
@@ -74,12 +74,17 @@ if [[ ! -d "${configdir}" ]]; then
 fi
 
 if [[ ! -f "${configFile}" ]]; then
+    dummyConfigCreated="true"
     echo "{\"auths\":{}}" >> ${configFile}
     chown ${scriptRunner} ${configFile}
 fi
 
 ./${tempdir}/config-edit --helper acr-${os} --config-file ${configFile} --force
 chown ${scriptRunner} ${configFile}
+
+if [[ ! -z "${dummyConfigCreated}" ]]; then
+    rm -f "${configFile}.bak"
+fi
 
 if [[ -z "$skipCleanup" ]]; then
     rm -f ${archiveFile}


### PR DESCRIPTION
Right now, if you don't have a config file already. The installer will create a temporary one because config-edit, being just an editor, assumes a config file is already there.

That dummy file should not be backed up.