### PR TITLE
Always use filestore on windows

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -3,6 +3,16 @@ param (
     [switch] $skipCleanup
 )
 
+Write-Host "ACR Credential Helper currently does not support Windows Credential Manager because Windows Credential Manager only support saving tokens with less than 2.5KB blob size."
+Write-Host "1. A json file will be used to store all your credentials."
+Write-Host "2. You will have to re-login to any existing Docker registry after the installation."
+$acceptFileStore = Read-Host "Continue? [Y/n]"
+
+if (!$acceptFileStore.ToLower().StartsWith("y")) {
+    Write-Error "User aborted."
+    break
+}
+
 $systemStr = (Get-WmiObject -Class Win32_ComputerSystem).SystemType
 if ($systemStr -match '(x64)') {
     $arch = "amd64"

--- a/src/docker-credential-acr/helper_wincred.go
+++ b/src/docker-credential-acr/helper_wincred.go
@@ -2,5 +2,5 @@
 
 package main
 
-const helperSuffix = "wincred"
+const helperSuffix = ""
 const exeFinder = "where.exe"

--- a/src/docker-credential-acr/program.go
+++ b/src/docker-credential-acr/program.go
@@ -105,7 +105,7 @@ func getCredentialsStore() (*dockerCredentials.Store, error) {
 	// secretservice for linux
 	// osxkeychain for osx
 	// if they are found. Otherwise it would revert to using native
-	if configHelperFound() {
+	if helperSuffix != "" && configHelperFound() {
 		store := dockerCredentials.NewNativeStore(config, helperSuffix)
 		return &store, nil
 	}


### PR DESCRIPTION
Windows Credential Manager only supports saving 2.5KB blob. For now, we would just not use it