### PR TITLE
Look up location of docker.exe in install script

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -35,7 +35,7 @@ if (!$isAdmin) {
     break
 }
 
-$dockerLocation = $(where.exe docker)
+$dockerLocation = $(where.exe docker.exe)
 if (!$dockerLocation) {
     Write-Error "Cannot find docker in path. Ensure it's installed and that its path is accessible."
     break


### PR DESCRIPTION
Recent versions of Docker for Windows install both `docker.exe` and `docker` in `C:\Program Files\Docker\Docker\resources\bin`, and both show up as results when running `where.exe`.

This change makes the lookup more specific to avoid the duplicate result.

Addresses #37.