### PR TITLE
fix: docker location is an array breaks the installation

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -40,6 +40,9 @@ if (!$dockerLocation) {
     Write-Error "Cannot find docker in path. Ensure it's installed and that its path is accessible."
     break
 }
+if($dockerLocation -is [System.Array]) {
+    $dockerLocation = $dockerLocation[0]
+}
 $installLocation = Split-Path $dockerLocation
 
 $tempdir = "deleteme"


### PR DESCRIPTION
I attempted to install this and the install script threw an error because where.exe returned multiple items for docker (all in the same folder)